### PR TITLE
[feat] 사업자 정보 조회 및 seller 정보 저장

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	implementation("org.springframework.boot:spring-boot-starter-validation")
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/hackathon/kb/chakchak/domain/member/api/controller/SellerController.java
+++ b/src/main/java/hackathon/kb/chakchak/domain/member/api/controller/SellerController.java
@@ -1,0 +1,31 @@
+package hackathon.kb.chakchak.domain.member.api.controller;
+
+import hackathon.kb.chakchak.domain.member.api.dto.BizRegisterRequest;
+import hackathon.kb.chakchak.domain.member.api.dto.BizRegisterResponse;
+import hackathon.kb.chakchak.domain.member.domain.entity.Seller;
+import hackathon.kb.chakchak.domain.member.service.SellerService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Validated
+@RequestMapping("/api/sellers")
+@RequiredArgsConstructor
+public class SellerController {
+    private final SellerService sellerService;
+
+    @PostMapping("/register")
+    public ResponseEntity<BizRegisterResponse> register(
+            @Valid @RequestBody BizRegisterRequest req
+            /// @AuthenticationPrincipal CustomUser customUser 추가
+    ) {
+        Seller saved = sellerService.updateSellerFromApick(req.getBizNo(), 4L); /// customUser 정보 받아오도록 수정
+        return ResponseEntity.ok(BizRegisterResponse.from(saved));
+    }
+}

--- a/src/main/java/hackathon/kb/chakchak/domain/member/api/dto/BizRegisterRequest.java
+++ b/src/main/java/hackathon/kb/chakchak/domain/member/api/dto/BizRegisterRequest.java
@@ -1,0 +1,10 @@
+package hackathon.kb.chakchak.domain.member.api.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class BizRegisterRequest {
+    @NotBlank(message = "사업자등록번호는 필수입니다.")
+    private String bizNo;
+}

--- a/src/main/java/hackathon/kb/chakchak/domain/member/api/dto/BizRegisterResponse.java
+++ b/src/main/java/hackathon/kb/chakchak/domain/member/api/dto/BizRegisterResponse.java
@@ -1,0 +1,35 @@
+package hackathon.kb.chakchak.domain.member.api.dto;
+
+import hackathon.kb.chakchak.domain.member.domain.entity.Seller;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class BizRegisterResponse {
+    private Long id;
+    private String bizNo;
+    private String companyName;
+    private String repName;
+    private String industryBusinessType;
+    private String bizDescription;
+    private String companyPhoneNumber;
+    private String zipCode;
+    private String roadNameAddress;
+    private String companyClassificationCode;
+
+    public static BizRegisterResponse from(Seller s) {
+        return BizRegisterResponse.builder()
+                .id(s.getId())
+                .bizNo(s.getBizNo())
+                .companyName(s.getCompanyName())
+                .repName(s.getRepName())
+                .industryBusinessType(s.getIndustryBusinessType())
+                .bizDescription(s.getBizDescription())
+                .companyPhoneNumber(s.getCompanyPhoneNumber())
+                .zipCode(s.getZipCode())
+                .roadNameAddress(s.getRoadNameAddress())
+                .companyClassificationCode(s.getCompanyClassificationCode())
+                .build();
+    }
+}

--- a/src/main/java/hackathon/kb/chakchak/domain/member/repository/BuyerRepository.java
+++ b/src/main/java/hackathon/kb/chakchak/domain/member/repository/BuyerRepository.java
@@ -1,0 +1,9 @@
+package hackathon.kb.chakchak.domain.member.repository;
+
+import hackathon.kb.chakchak.domain.member.domain.entity.Buyer;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BuyerRepository extends JpaRepository<Buyer, Long> {
+}

--- a/src/main/java/hackathon/kb/chakchak/domain/member/repository/MemberRepository.java
+++ b/src/main/java/hackathon/kb/chakchak/domain/member/repository/MemberRepository.java
@@ -1,0 +1,43 @@
+package hackathon.kb.chakchak.domain.member.repository;
+
+import hackathon.kb.chakchak.domain.member.domain.entity.Buyer;
+import hackathon.kb.chakchak.domain.member.domain.entity.Member;
+import hackathon.kb.chakchak.domain.member.domain.entity.Seller;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member,Long> {
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(value = """
+        UPDATE member
+           SET inheritance_type = 'SELLER',
+               role              = 'SELLER',
+               biz_no                       = :bizNo,
+               company_name                 = :companyName,
+               rep_name                     = :repName,
+               industry_business_type       = :industryBusinessType,
+               biz_description              = :bizDescription,
+               company_phone_number         = :companyPhoneNumber,
+               zip_code                     = :zipCode,
+               road_name_address            = :roadNameAddress,
+               company_classification_code  = :companyClassificationCode
+         WHERE member_id = :memberId
+        """, nativeQuery = true)
+    int promoteBuyerToSeller(
+            @Param("memberId") Long memberId,
+            @Param("bizNo") String bizNo,
+            @Param("companyName") String companyName,
+            @Param("repName") String repName,
+            @Param("industryBusinessType") String industryBusinessType,
+            @Param("bizDescription") String bizDescription,
+            @Param("companyPhoneNumber") String companyPhoneNumber,
+            @Param("zipCode") String zipCode,
+            @Param("roadNameAddress") String roadNameAddress,
+            @Param("companyClassificationCode") String companyClassificationCode
+    );
+}

--- a/src/main/java/hackathon/kb/chakchak/domain/member/repository/SellerRepository.java
+++ b/src/main/java/hackathon/kb/chakchak/domain/member/repository/SellerRepository.java
@@ -1,0 +1,9 @@
+package hackathon.kb.chakchak.domain.member.repository;
+
+import hackathon.kb.chakchak.domain.member.domain.entity.Seller;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SellerRepository extends JpaRepository<Seller, Long> {
+}

--- a/src/main/java/hackathon/kb/chakchak/domain/member/service/MemberRolePromotionService.java
+++ b/src/main/java/hackathon/kb/chakchak/domain/member/service/MemberRolePromotionService.java
@@ -1,0 +1,57 @@
+package hackathon.kb.chakchak.domain.member.service;
+
+import hackathon.kb.chakchak.domain.member.domain.entity.Member;
+import hackathon.kb.chakchak.domain.member.domain.entity.Seller;
+import hackathon.kb.chakchak.domain.member.repository.MemberRepository;
+import hackathon.kb.chakchak.domain.member.service.dto.ApickBizDetailResponse;
+import hackathon.kb.chakchak.global.exception.exceptions.BusinessException;
+import hackathon.kb.chakchak.global.response.ResponseCode;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MemberRolePromotionService {
+    private final MemberRepository memberRepository;
+    private final EntityManager em;
+
+    @Transactional
+    public Seller promoteBuyerToSeller(Long memberId, ApickBizDetailResponse.Data d) {
+        int rows = memberRepository.promoteBuyerToSeller(
+                memberId,
+                digits(d.getBizNo(), 20),
+                d.getCompanyName(),
+                d.getRepName(),
+                d.getIndustryBusinessType(),
+                d.getBizDescription(),
+                digits(d.getPhoneNumber(), 11),
+                digits(d.getZipCode(), 5),
+                d.getRoadNameAddress(),
+                digits(d.getCompanyClassificationCode(), 6)
+        );
+        if (rows != 1) throw new BusinessException(ResponseCode.CONFLICT);
+
+        em.flush();
+        em.clear();
+
+        Member reloaded = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(ResponseCode.NOT_FOUND));
+
+        if (!(reloaded instanceof Seller seller)) {
+            throw new BusinessException(ResponseCode.INTERNAL_SERVER_ERROR);
+        }
+        return seller;
+    }
+
+    private String digits(String s, int max) {
+        if (s == null) return null;
+        String only = s.replaceAll("\\D", "");
+        String tmp = only.length() > max ? only.substring(0, max) : only;
+        System.out.println("tmp = " + tmp);
+        return tmp;
+    }
+}

--- a/src/main/java/hackathon/kb/chakchak/domain/member/service/SellerService.java
+++ b/src/main/java/hackathon/kb/chakchak/domain/member/service/SellerService.java
@@ -1,0 +1,78 @@
+package hackathon.kb.chakchak.domain.member.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import hackathon.kb.chakchak.domain.member.domain.entity.Member;
+import hackathon.kb.chakchak.domain.member.domain.entity.Seller;
+import hackathon.kb.chakchak.domain.member.repository.MemberRepository;
+import hackathon.kb.chakchak.domain.member.service.dto.ApickBizDetailResponse;
+import hackathon.kb.chakchak.global.exception.exceptions.BusinessException;
+import hackathon.kb.chakchak.global.response.ResponseCode;
+import hackathon.kb.chakchak.global.util.ApiConnectionUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class SellerService {
+    private final MemberRepository memberRepository;
+    private final MemberRolePromotionService promotionService;
+    private final RestTemplate restTemplate;
+
+    @Value("${apick.base-url}")
+    private String baseUrl;
+
+    @Value("${apick.auth-key}")
+    private String authKey;
+
+    @Transactional
+    public Seller updateSellerFromApick(String bizNo, Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(ResponseCode.UNAUTHORIZED));
+        if (member instanceof Seller seller) return seller;
+
+        ApickBizDetailResponse.Data d = callApick(bizNo);
+        return promotionService.promoteBuyerToSeller(member.getId(), d);
+    }
+
+
+    private ApickBizDetailResponse.Data callApick(String bizNo) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.add("CL_AUTH_KEY", authKey);
+
+        var form = new LinkedMultiValueMap<String, String>();
+        form.add("biz_no", bizNo);
+
+        var req = new HttpEntity<>(form, headers);
+
+        ResponseEntity<String> raw = restTemplate.postForEntity(baseUrl, req, String.class);
+        //log.info("[Apick RAW] status={} body={}", raw.getStatusCode(), raw.getBody());
+
+        if (!raw.getStatusCode().is2xxSuccessful() || raw.getBody() == null) {
+            throw new BusinessException(ResponseCode.BAD_REQUEST);
+        }
+
+        ApickBizDetailResponse parsed = ApiConnectionUtil.decodeJsonStringToDto(
+                raw.getBody(),
+                new TypeReference<ApickBizDetailResponse>() {
+                },
+                ApiConnectionUtil.CAMEL
+        );
+
+        if (parsed == null || !parsed.isSuccess() || parsed.getData() == null) {
+            throw new BusinessException(ResponseCode.BAD_REQUEST);
+        }
+        return parsed.getData();
+    }
+}

--- a/src/main/java/hackathon/kb/chakchak/domain/member/service/dto/ApickBizDetailResponse.java
+++ b/src/main/java/hackathon/kb/chakchak/domain/member/service/dto/ApickBizDetailResponse.java
@@ -1,0 +1,57 @@
+package hackathon.kb.chakchak.domain.member.service.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ApickBizDetailResponse {
+
+    @JsonProperty("api")
+    private Api api;
+
+    @JsonProperty("data")
+    private Data data;
+
+    public boolean isSuccess() {
+        return api != null && Boolean.TRUE.equals(api.getSuccess());
+    }
+
+    @Getter
+    @Setter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Api {
+        private Boolean success;
+        private Integer cost;
+        private Integer ms;
+        @JsonProperty("pl_id")
+        private Long plId;
+    }
+
+    @Getter
+    @Setter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Data {
+        @JsonProperty("회사명")
+        private String companyName;
+        @JsonProperty("사업자등록번호")
+        private String bizNo;
+        @JsonProperty("대표명")
+        private String repName;
+        @JsonProperty("업태")
+        private String industryBusinessType;
+        @JsonProperty("종목")
+        private String bizDescription;
+        @JsonProperty("전화번호")
+        private String phoneNumber;
+        @JsonProperty("우편번호")
+        private String zipCode;
+        @JsonProperty("도로명주소")
+        private String roadNameAddress;
+        @JsonProperty("표준산업분류(노동부) 업종코드")
+        private String companyClassificationCode;
+    }
+}

--- a/src/main/java/hackathon/kb/chakchak/global/httpclient/HttpClientConfig.java
+++ b/src/main/java/hackathon/kb/chakchak/global/httpclient/HttpClientConfig.java
@@ -1,0 +1,13 @@
+package hackathon.kb.chakchak.global.httpclient;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class HttpClientConfig {
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/hackathon/kb/chakchak/global/response/ResponseCode.java
+++ b/src/main/java/hackathon/kb/chakchak/global/response/ResponseCode.java
@@ -12,7 +12,11 @@ public enum ResponseCode {
 	// GENERAL
 	SUCCESS("GEN-000", HttpStatus.OK, "Success"),
 	BAD_REQUEST("GEN-001", HttpStatus.BAD_REQUEST, "Bad Request"),
-	UNAUTHORIZED("GEN-002", HttpStatus.UNAUTHORIZED, "Unauthorized");
+	UNAUTHORIZED("GEN-002", HttpStatus.UNAUTHORIZED, "Unauthorized"),
+	NOT_FOUND("GEN-003", HttpStatus.NOT_FOUND, "Not Found"),
+	CONFLICT("GEN-004", HttpStatus.CONFLICT, "Conflict"),
+	INTERNAL_SERVER_ERROR("GEN-005", HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error");
+
 
 	private final String code;
 	private final HttpStatus status;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,3 +15,8 @@ spring:
       hibernate:
         format_sql: true
         show_sql: true
+
+  apick:
+    base_url: ${APICK_BASE_URL}
+    auth_key: ${APICK_AUTH_KEY}
+


### PR DESCRIPTION
## 🔖 PR 유형
- [X] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
사업자등록번호를 토대로 에이픽 api로 관련 정보를 받아오고, 회원을 seller로 전환 및 정보 저장

## 🔧 작업 내용
- `SellerController` : /api/sellers/register 엔드포인트 구현
- `SellerService` : Apick API 호출 및 사업자 정보 반영
- `MemberRolePromotionService` : Buyer → Seller 승격 처리
- `HttpClientConfig` : RestTemplate Bean 등록
- `build.gradle`, `application.yml` 환경 설정 수정

## ✅ 체크리스트
- [X] 테스트 완료(Postman, Swagger)

## 📝 기타 참고 사항
- `SellerController` : 추후 @AuthenticationPrincipal CustomUser customUser 추가

## 📎 관련 이슈
Close #1 