### PR TITLE
[feature] 행정구역 코드 API 연결 

### DIFF
--- a/src/main/java/hackathon/kb/chakchak/domain/member/domain/entity/Seller.java
+++ b/src/main/java/hackathon/kb/chakchak/domain/member/domain/entity/Seller.java
@@ -58,4 +58,7 @@ public class Seller extends Member {
 
 	@Column(length = 25)
 	private String accountNumber; 			// (seller) 판매자 계좌 번호
+
+	@Column(length = 10)
+	private String admCd;
 }

--- a/src/main/java/hackathon/kb/chakchak/global/utils/api/juso/AdmCodeLookupController.java
+++ b/src/main/java/hackathon/kb/chakchak/global/utils/api/juso/AdmCodeLookupController.java
@@ -1,0 +1,39 @@
+package hackathon.kb.chakchak.global.utils.api.juso;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import hackathon.kb.chakchak.global.utils.api.juso.dto.AdmCdResponse;
+
+@RestController
+@RequestMapping("/internal/juso")
+public class AdmCodeLookupController {
+
+	private final JusoApiClient jusoService;
+
+	public AdmCodeLookupController(JusoApiClient jusoService) {
+		this.jusoService = jusoService;
+	}
+
+	/**
+	 * 도로명 주소 → 행정동 코드(admCd) 단건 변환
+	 * 예: GET /internal/juso/admcd?roadAddress=서울특별시 강남구 테헤란로 123
+	 */
+	@GetMapping("/admcd")
+	public ResponseEntity<AdmCdResponse> getAdmCd(@RequestParam("roadNameAddress") String roadNameAddress) {
+		if (!StringUtils.hasText(roadNameAddress)) {
+			return ResponseEntity.badRequest().build();
+		}
+
+		String admCd = jusoService.requestAdmCd(roadNameAddress);
+		if (!StringUtils.hasText(admCd)) {
+			return ResponseEntity.notFound().build();
+		}
+
+		return ResponseEntity.ok(new AdmCdResponse(admCd));
+	}
+}

--- a/src/main/java/hackathon/kb/chakchak/global/utils/api/juso/JusoApiClient.java
+++ b/src/main/java/hackathon/kb/chakchak/global/utils/api/juso/JusoApiClient.java
@@ -1,0 +1,56 @@
+package hackathon.kb.chakchak.global.utils.api.juso;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import hackathon.kb.chakchak.global.utils.api.juso.dto.JusoSearchResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+public class JusoApiClient {
+
+	@Value("${JUSO_ADMCD_BASE_URL}")
+	private String baseUrl;
+
+	@Value("${JUSO_ADMCD_API_KEY}")
+	private String apiKey;
+
+	// 간단 사용용 RestClient
+	// 추후 Bean으로 등록해야 함
+	private final RestClient rest = RestClient.create();
+
+	// request 함수
+	public String requestAdmCd(String roadNameAddress) {
+		if (!StringUtils.hasText(roadNameAddress)) {
+			return null;
+		}
+
+		String uri = UriComponentsBuilder.fromHttpUrl(baseUrl)
+			.queryParam("confmKey", apiKey)
+			.queryParam("currentPage", 1)
+			.queryParam("countPerPage", 1)
+			.queryParam("keyword", roadNameAddress)
+			.queryParam("resultType", "json")
+			.build()
+			.toUriString();
+		log.info("JUSO request: {}", baseUrl);
+
+		JusoSearchResponse body = rest.get()
+			.uri(uri)
+			.retrieve()
+			.body(JusoSearchResponse.class);
+
+		if (body == null || body.getResults() == null || body.getResults().getJuso() == null) {
+			return null;
+		}
+
+		return body.getResults().getJuso().stream()
+			.map(JusoSearchResponse.Juso::getAdmCd)
+			.findFirst()
+			.orElse(null);
+	}
+}

--- a/src/main/java/hackathon/kb/chakchak/global/utils/api/juso/dto/AdmCdResponse.java
+++ b/src/main/java/hackathon/kb/chakchak/global/utils/api/juso/dto/AdmCdResponse.java
@@ -1,0 +1,14 @@
+package hackathon.kb.chakchak.global.utils.api.juso.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AdmCdResponse {
+	private String admCd;
+
+	public AdmCdResponse(String admCd) {
+		this.admCd = admCd;		// 행정동 코드
+	}
+}

--- a/src/main/java/hackathon/kb/chakchak/global/utils/api/juso/dto/JusoSearchResponse.java
+++ b/src/main/java/hackathon/kb/chakchak/global/utils/api/juso/dto/JusoSearchResponse.java
@@ -1,0 +1,24 @@
+package hackathon.kb.chakchak.global.utils.api.juso.dto;
+
+import java.util.List;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class JusoSearchResponse {
+	private Results results;
+
+	@Getter
+	@NoArgsConstructor
+	public static class Results {
+		private List<Juso> juso;
+	}
+
+	@Getter
+	@NoArgsConstructor
+	public static class Juso {
+		private String admCd;	// 행정동 코드
+	}
+}


### PR DESCRIPTION
## 🔖 PR 유형
- [ v ] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
도로명 주소에서 행정동 코드(7자리)를 추출하기 위해 juso api 호출

## 🔧 작업 내용
- `Seller`: 행정동 코드 컬럼 추가
- `JusoSearchResponse`: 주소 API용 외부 응답 DTO
- `AdmCdResponse`: 내부 응답 DTO
- `JusoApiClient`: 도로명 주소에서 행정동 코드 추출
- `AdmCodeLookupController`: 행정동 코드 추출 로직 확인용 컨트롤러
- 추후 사업자 정보 조회 로직과 연동

## ✅ 체크리스트
- [ v ] 테스트 완료(Postman, Swagger)

## 📝 기타 참고 사항
- 주의할 점, 추후 리팩토링 필요성 등

## 📎 관련 이슈
Close #이슈번호