### PR TITLE
[feature] 사업자 정보 조회와 행정동 코드 기능 연결

### DIFF
--- a/src/main/java/hackathon/kb/chakchak/domain/member/domain/entity/Seller.java
+++ b/src/main/java/hackathon/kb/chakchak/domain/member/domain/entity/Seller.java
@@ -60,5 +60,5 @@ public class Seller extends Member {
 	private String accountNumber; 			// (seller) 판매자 계좌 번호
 
 	@Column(length = 10)
-	private String admCd;
+	private String admCd;					// (seller) 행정동 코드
 }

--- a/src/main/java/hackathon/kb/chakchak/domain/member/repository/MemberRepository.java
+++ b/src/main/java/hackathon/kb/chakchak/domain/member/repository/MemberRepository.java
@@ -3,6 +3,8 @@ package hackathon.kb.chakchak.domain.member.repository;
 import hackathon.kb.chakchak.domain.member.domain.entity.Buyer;
 import hackathon.kb.chakchak.domain.member.domain.entity.Member;
 import hackathon.kb.chakchak.domain.member.domain.entity.Seller;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -40,4 +42,8 @@ public interface MemberRepository extends JpaRepository<Member,Long> {
             @Param("roadNameAddress") String roadNameAddress,
             @Param("companyClassificationCode") String companyClassificationCode
     );
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Seller s SET s.admCd = :admCd WHERE s.id = :sellerId")
+    int updateSellerAdmCd(@Param("sellerId") Long sellerId, @Param("admCd") String admcd);
 }

--- a/src/main/java/hackathon/kb/chakchak/domain/member/repository/MemberRepository.java
+++ b/src/main/java/hackathon/kb/chakchak/domain/member/repository/MemberRepository.java
@@ -27,7 +27,8 @@ public interface MemberRepository extends JpaRepository<Member,Long> {
                company_phone_number         = :companyPhoneNumber,
                zip_code                     = :zipCode,
                road_name_address            = :roadNameAddress,
-               company_classification_code  = :companyClassificationCode
+               company_classification_code  = :companyClassificationCode,
+                adm_cd                      = :admCd
          WHERE member_id = :memberId
         """, nativeQuery = true)
     int promoteBuyerToSeller(
@@ -40,10 +41,11 @@ public interface MemberRepository extends JpaRepository<Member,Long> {
             @Param("companyPhoneNumber") String companyPhoneNumber,
             @Param("zipCode") String zipCode,
             @Param("roadNameAddress") String roadNameAddress,
-            @Param("companyClassificationCode") String companyClassificationCode
+            @Param("companyClassificationCode") String companyClassificationCode,
+            @Param("admCd") String admCd
     );
 
-    @Modifying(clearAutomatically = true)
-    @Query("UPDATE Seller s SET s.admCd = :admCd WHERE s.id = :sellerId")
-    int updateSellerAdmCd(@Param("sellerId") Long sellerId, @Param("admCd") String admcd);
+    // @Modifying(clearAutomatically = true)
+    // @Query("UPDATE Seller s SET s.admCd = :admCd WHERE s.id = :sellerId")
+    // int updateSellerAdmCd(@Param("sellerId") Long sellerId, @Param("admCd") String admcd);
 }

--- a/src/main/java/hackathon/kb/chakchak/domain/member/service/MemberRolePromotionService.java
+++ b/src/main/java/hackathon/kb/chakchak/domain/member/service/MemberRolePromotionService.java
@@ -20,7 +20,7 @@ public class MemberRolePromotionService {
     private final EntityManager em;
 
     @Transactional
-    public Seller promoteBuyerToSeller(Long memberId, ApickBizDetailResponse.Data d) {
+    public Seller promoteBuyerToSeller(Long memberId, ApickBizDetailResponse.Data d, String admCd) {
         int rows = memberRepository.promoteBuyerToSeller(
                 memberId,
                 digits(d.getBizNo(), 20),
@@ -31,7 +31,8 @@ public class MemberRolePromotionService {
                 digits(d.getPhoneNumber(), 11),
                 digits(d.getZipCode(), 5),
                 d.getRoadNameAddress(),
-                digits(d.getCompanyClassificationCode(), 6)
+                digits(d.getCompanyClassificationCode(), 6),
+                admCd
         );
         if (rows != 1) throw new BusinessException(ResponseCode.CONFLICT);
 

--- a/src/main/java/hackathon/kb/chakchak/domain/member/service/SellerService.java
+++ b/src/main/java/hackathon/kb/chakchak/domain/member/service/SellerService.java
@@ -11,6 +11,7 @@ import hackathon.kb.chakchak.global.util.ApiConnectionUtil;
 import hackathon.kb.chakchak.global.utils.api.juso.JusoApiClient;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -44,22 +45,42 @@ public class SellerService {
         if (member instanceof Seller seller) return seller;
 
         // 1. Apick API -> 사업자 정보
-        ApickBizDetailResponse.Data d = callApick(bizNo);
-
-        // 2. promoition
-        Seller newSeller = promotionService.promoteBuyerToSeller(member.getId(), d);
-
-        // 3. get admCd
-        String admCd = jusoApiClient.requestAdmCd(newSeller.getRoadNameAddress());
-
-        // 4. DB 반영
-        if (admCd != null) {
-            memberRepository.updateSellerAdmCd(newSeller.getId(), admCd);
+        ApickBizDetailResponse.Data d;
+        try {
+            d = callApick(bizNo);
+        } catch (Exception e) {
+            log.error("Apick API 호출 실패: bizNo={}, memberId={}", bizNo, memberId, e);
+            throw new BusinessException(ResponseCode.INTERNAL_SERVER_ERROR);
         }
 
-        return newSeller;
-    }
+        // 2. admCd
+        String roadNameAddress = d.getRoadNameAddress();
+        if (roadNameAddress == null || roadNameAddress.isBlank()) {
+            log.warn("도로명 주소 없음 bizNo={}, memberId={}", bizNo, memberId);
+            throw new BusinessException(ResponseCode.BAD_REQUEST);
+        }
 
+        String admCd;
+        try {
+            admCd = jusoApiClient.requestAdmCd(roadNameAddress);
+        } catch (Exception e) {
+            log.error("Juso 호출 실패 memberId={}, road={}", memberId, roadNameAddress, e);
+            throw new BusinessException(ResponseCode.INTERNAL_SERVER_ERROR);
+        }
+
+        if (admCd == null || admCd.isBlank()) {
+            log.warn("Juso 응답에 admCd 없음 memberId={}, road={}", memberId, roadNameAddress);
+            throw new BusinessException(ResponseCode.BAD_REQUEST);
+        }
+
+        // 3. promoition
+        try {
+            return promotionService.promoteBuyerToSeller(member.getId(), d, admCd);
+        } catch (Exception e) {
+            log.error("승급 실패 memberId={}", memberId, e);
+            throw new BusinessException(ResponseCode.CONFLICT);
+        }
+    }
 
     private ApickBizDetailResponse.Data callApick(String bizNo) {
         HttpHeaders headers = new HttpHeaders();

--- a/src/main/java/hackathon/kb/chakchak/global/utils/api/juso/JusoApiClient.java
+++ b/src/main/java/hackathon/kb/chakchak/global/utils/api/juso/JusoApiClient.java
@@ -13,10 +13,10 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class JusoApiClient {
 
-	@Value("${JUSO_ADMCD_BASE_URL}")
+	@Value("${juso.base-url}")
 	private String baseUrl;
 
-	@Value("${JUSO_ADMCD_API_KEY}")
+	@Value("${juso.api-key}")
 	private String apiKey;
 
 	// 간단 사용용 RestClient

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,9 +3,9 @@ spring:
     name: chakchak
 
   datasource:
-    url: ${DB_URL}
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
+    url: jdbc:mysql://localhost:3306/chakchak?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: root
+    password: root1234
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:
@@ -29,16 +29,19 @@ spring:
       properties:
         spring.json.add.type.headers: false  # 수신 측 타입 헤더 미포함(호환성)
 
-  apick:
-    base_url: ${APICK_BASE_URL}
-    auth_key: ${APICK_AUTH_KEY}
+apick:
+  base-url: ${APICK_BASE_URL}
+  auth-key: ${APICK_AUTH_KEY}
 
-  openai:
-    api:
-      key: ${OPENAI_API_KEY}
-      url: ${OPENAI_API_URL}
-      model: ${OPENAI_API_MODEL}
+openai:
+  api:
+    key: ${OPENAI_API_KEY}
+    url: ${OPENAI_API_URL}
+    model: ${OPENAI_API_MODEL}
 
+juso:
+  base-url: ${JUSO_ADMCD_BASE_URL}
+  api-key: ${JUSO_ADMCD_API_KEY}
 
 springdoc:
   api-docs:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,9 +3,9 @@ spring:
     name: chakchak
 
   datasource:
-    url: jdbc:mysql://localhost:3306/chakchak?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-    username: root
-    password: root1234
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:
@@ -30,8 +30,8 @@ spring:
         spring.json.add.type.headers: false  # 수신 측 타입 헤더 미포함(호환성)
 
   apick:
-    base-url: ${APICK_BASE_URL}
-    auth-key: ${APICK_AUTH_KEY}
+    base_url: ${APICK_BASE_URL}
+    auth_key: ${APICK_AUTH_KEY}
 
   openai:
     api:


### PR DESCRIPTION
## 🔖 PR 유형
- [x] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [x] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
사업자 번호로 등록 후, 도로명 주소로 행정동 코드 추출

## 🔧 작업 내용
- 기존에 사업자 번호 진위여부 확인 후 buyer로 승급하는 로직을 행정동 코드 발급 후 승급하도록 변경
- `sellerService` 에러 처리

## ✅ 체크리스트
- [x] 테스트 완료(Postman, Swagger)
<img width="266" height="505" alt="Screenshot 2025-09-04 at 12 01 19 AM" src="https://github.com/user-attachments/assets/b48fe9ed-f547-49bd-8d29-88d66956454c" />


## 📝 기타 참고 사항
- 주의할 점, 추후 리팩토링 필요성 등

## 📎 관련 이슈
Close #16