### PR TITLE
[fix] 상품 저장 로직 수정

### DIFF
--- a/src/main/java/hackathon/kb/chakchak/domain/product/api/controller/ProductController.java
+++ b/src/main/java/hackathon/kb/chakchak/domain/product/api/controller/ProductController.java
@@ -3,19 +3,19 @@ package hackathon.kb.chakchak.domain.product.api.controller;
 import hackathon.kb.chakchak.domain.auth.MemberPrincipal;
 import hackathon.kb.chakchak.domain.product.api.dto.ProductMetaRequest;
 import hackathon.kb.chakchak.domain.product.api.dto.ProductSaveRequest;
+import hackathon.kb.chakchak.domain.product.api.dto.ProductSaveResponse;
 import hackathon.kb.chakchak.domain.product.service.ProductCommandService;
 import hackathon.kb.chakchak.domain.product.service.ProductNarrativeService;
 import hackathon.kb.chakchak.domain.product.service.dto.NarrativeResult;
+import hackathon.kb.chakchak.global.response.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -26,20 +26,20 @@ public class ProductController {
     private final ProductCommandService productCommandService;
 
     @Operation(summary = "gpt 문구 받아오기", description = "상품 정보를 토대로 gpt 피드 문구 및 태그를 받아옵니다.")
-    @PostMapping(value = "/narrative", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<NarrativeResult> makeNarrative(
-            @RequestPart("meta") ProductMetaRequest meta,
-            @RequestPart("images") List<MultipartFile> images,
+    @PostMapping("/narrative")
+    public BaseResponse<NarrativeResult> makeNarrative(
+            @RequestBody ProductMetaRequest meta,
             @AuthenticationPrincipal MemberPrincipal principal
     ) {
-        return ResponseEntity.ok(
-                productNarrativeService.createNarrative(principal.getId(), meta, images));
+        return BaseResponse.OK(
+                productNarrativeService.createNarrative(principal.getId(), meta));
     }
 
     @Operation(summary = "상품 등록", description = "상품 정보를 최종 등록합니다.")
     @PostMapping("/save")
-    public ResponseEntity<Void> saveProduct(@RequestBody ProductSaveRequest req) {
-        Long productId = productCommandService.saveProduct(req);
-        return ResponseEntity.ok().build();
+    public BaseResponse<ProductSaveResponse> saveProduct(
+            @RequestBody ProductSaveRequest req,
+            @AuthenticationPrincipal MemberPrincipal principal) {
+        return BaseResponse.OK(productCommandService.saveProduct(principal.getId(), req));
     }
 }

--- a/src/main/java/hackathon/kb/chakchak/domain/product/api/dto/ProductMetaRequest.java
+++ b/src/main/java/hackathon/kb/chakchak/domain/product/api/dto/ProductMetaRequest.java
@@ -4,6 +4,8 @@ import hackathon.kb.chakchak.domain.product.domain.enums.Category;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
+import java.util.List;
+
 @Data
 public class ProductMetaRequest {
     @Schema(description = "상품명", example = "콜드브루 몰트 크림")
@@ -14,5 +16,8 @@ public class ProductMetaRequest {
 
     @Schema(description = "상품 요약 설명", example = "여름에 딱 맞는 진한 콜드브루와 부드러운 몰트 크림 조합")
     private String summary;
+
+    @Schema(description = "상품 이미지 url", example = "[\"https://chakchak-img/0.png\", \"https://chakchak-img/1.png\"]")
+    private List<String> images;
 }
 

--- a/src/main/java/hackathon/kb/chakchak/domain/product/api/dto/ProductSaveRequest.java
+++ b/src/main/java/hackathon/kb/chakchak/domain/product/api/dto/ProductSaveRequest.java
@@ -1,5 +1,6 @@
 package hackathon.kb.chakchak.domain.product.api.dto;
 
+import hackathon.kb.chakchak.domain.product.domain.enums.Category;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
@@ -8,8 +9,14 @@ import java.util.List;
 
 @Data
 public class ProductSaveRequest {
-    @Schema(description = "상품 ID (기존 상품 식별자)", example = "12")
-    private Long productId;
+    @Schema(description = "상품명", example = "콜드브루 몰트 크림")
+    private String title;
+
+    @Schema(description = "상품 카테고리", example = "카페")
+    private Category category;
+
+    @Schema(description = "상품 이미지 url", example = "[\"https://chakchak-img/0.png\", \"https://chakchak-img/1.png\"]")
+    private List<String> images;
 
     @Schema(description = "상품 상세 설명", example = "여름의 시작을 알리는 특별한 순간...")
     private String description;
@@ -22,6 +29,12 @@ public class ProductSaveRequest {
 
     @Schema(description = "쿠폰 사용 가능 여부", example = "true")
     private Boolean isCoupon;
+
+    @Schema(description = "상품 쿠폰명", example = "콜드브루 몰트 1회 사용권")
+    private String couponName;
+
+    @Schema(description = "쿠폰 유효기간 일시", example = "2025-10-05T00:00:00")
+    private LocalDateTime couponExpiration;
 
     @Schema(description = "목표 수량", example = "100")
     private Short targetAmount;

--- a/src/main/java/hackathon/kb/chakchak/domain/product/api/dto/ProductSaveResponse.java
+++ b/src/main/java/hackathon/kb/chakchak/domain/product/api/dto/ProductSaveResponse.java
@@ -1,0 +1,4 @@
+package hackathon.kb.chakchak.domain.product.api.dto;
+
+public record ProductSaveResponse(Long productId) {
+}

--- a/src/main/java/hackathon/kb/chakchak/domain/product/domain/entity/Product.java
+++ b/src/main/java/hackathon/kb/chakchak/domain/product/domain/entity/Product.java
@@ -49,8 +49,6 @@ public class Product extends BaseEntity {
 	@Column(nullable = false)
 	private Long price;
 
-	private boolean isCoupon;
-
 	@Lob
 	@Column(columnDefinition = "LONGTEXT", nullable = false)
 	private String description;
@@ -59,6 +57,12 @@ public class Product extends BaseEntity {
 	private ProductStatus status;
 
 	private Short targetAmount;
+
+	private boolean isCoupon;
+
+	private String couponName;
+
+	private LocalDateTime couponExpiration;
 
 	@Column(nullable = false)
 	private LocalDateTime recruitmentStartPeriod;
@@ -69,41 +73,4 @@ public class Product extends BaseEntity {
 	private Short refreshCnt;
 
 	private LocalDateTime refreshedAt;
-
-
-	// ====== 변경 메서드 (업데이트 전용) ======
-
-	public void changeEndCaptureId(Long id) {
-		this.endCaptureId = id;
-	}
-
-	public void changeDescription(String description) {
-		if (description != null) this.description = description;
-	}
-
-	public void changePrice(Long price) {
-		if (price != null) this.price = price;
-	}
-
-	// boolean 필드는 null-safe 입력 메서드로
-	public void changeCoupon(Boolean isCoupon) {
-		if (isCoupon != null) this.isCoupon = isCoupon;
-	}
-
-	public void changeTargetAmount(Short targetAmount) {
-		if (targetAmount != null) this.targetAmount = targetAmount;
-	}
-
-	public void changeRecruitmentPeriods(LocalDateTime start, LocalDateTime end) {
-		if (start != null) this.recruitmentStartPeriod = start;
-		if (end != null) this.recruitmentEndPeriod = end;
-	}
-
-	public void markPending() {
-		this.status = ProductStatus.PENDING;
-	}
-
-	public void touchRefreshedAt(LocalDateTime now) {
-		this.refreshedAt = now;
-	}
 }

--- a/src/main/java/hackathon/kb/chakchak/domain/product/repository/ImageRepository.java
+++ b/src/main/java/hackathon/kb/chakchak/domain/product/repository/ImageRepository.java
@@ -1,7 +1,9 @@
 package hackathon.kb.chakchak.domain.product.repository;
 
 import hackathon.kb.chakchak.domain.product.domain.entity.Image;
+import hackathon.kb.chakchak.domain.product.domain.entity.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ImageRepository extends JpaRepository<Image, Long> {
+    void deleteByProduct(Product product);
 }

--- a/src/main/java/hackathon/kb/chakchak/domain/product/repository/TagRepository.java
+++ b/src/main/java/hackathon/kb/chakchak/domain/product/repository/TagRepository.java
@@ -1,7 +1,9 @@
 package hackathon.kb.chakchak.domain.product.repository;
 
+import hackathon.kb.chakchak.domain.product.domain.entity.Product;
 import hackathon.kb.chakchak.domain.product.domain.entity.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
+    void deleteByProduct(Product product);
 }

--- a/src/main/java/hackathon/kb/chakchak/domain/product/service/OpenAIMultimodalNarrativeService.java
+++ b/src/main/java/hackathon/kb/chakchak/domain/product/service/OpenAIMultimodalNarrativeService.java
@@ -29,7 +29,6 @@ public class OpenAIMultimodalNarrativeService {
     private String model;
 
     public NarrativeResult generateNarrativeWithImageUrls(
-            Long productId,
             String systemInstruction,
             String userText,
             List<String> imageUrls
@@ -54,7 +53,7 @@ public class OpenAIMultimodalNarrativeService {
         }
 
         String raw = callOnce(systemInstruction, userParts);
-        return tryParseJsonResult(productId, raw);
+        return tryParseJsonResult(raw);
     }
 
     /**
@@ -154,7 +153,7 @@ public class OpenAIMultimodalNarrativeService {
     }
 
     // JSON 파서
-    private NarrativeResult tryParseJsonResult(Long productId, String respText) {
+    private NarrativeResult tryParseJsonResult(String respText) {
         String text = tryParseResponsesApi(respText);
         if (text == null || text.isBlank()) {
             text = respText; // 모델이 곧장 JSON만 준 경우 대비
@@ -166,10 +165,10 @@ public class OpenAIMultimodalNarrativeService {
             String hashtagsRaw = root.path("hashtags").asText(null);
             List<String> hashtags = parseHashtags(hashtagsRaw);
 
-            return new NarrativeResult(productId, caption, hashtags);
+            return new NarrativeResult(caption, hashtags);
         } catch (Exception e) {
             log.warn("JSON 파싱 실패, 원문 반환 시도: {}", e.toString());
-            return new NarrativeResult(0L, text == null ? "" : text.trim(), Collections.emptyList());
+            return new NarrativeResult(text == null ? "" : text.trim(), Collections.emptyList());
         }
     }
 

--- a/src/main/java/hackathon/kb/chakchak/domain/product/service/dto/NarrativeResult.java
+++ b/src/main/java/hackathon/kb/chakchak/domain/product/service/dto/NarrativeResult.java
@@ -9,9 +9,6 @@ import java.util.List;
 @Getter
 @AllArgsConstructor
 public class NarrativeResult {
-    @Schema(description = "상품 ID", example = "12")
-    private final Long productId;
-
     @Schema(description = "상품 상세 설명 (홍보글)", example = "여름의 시작을 알리는 특별한 순간...")
     private final String caption;
 

--- a/src/main/java/hackathon/kb/chakchak/global/response/BaseResponse.java
+++ b/src/main/java/hackathon/kb/chakchak/global/response/BaseResponse.java
@@ -1,9 +1,8 @@
 package hackathon.kb.chakchak.global.response;
 
-import org.springframework.http.HttpStatus;
-
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 @Builder
@@ -19,6 +18,7 @@ public class BaseResponse<T> {
 		return BaseResponse
 			.<T>builder()
 			.code(code.getCode())
+				.status(code.getStatus())
 			.message(code.getMessage())
 			.data(data)
 			.build();
@@ -30,6 +30,7 @@ public class BaseResponse<T> {
 		return BaseResponse
 			.<T>builder()
 			.code(code.getCode())
+				.status(code.getStatus())
 			.message(code.getMessage())
 			.build();
 	}
@@ -39,6 +40,7 @@ public class BaseResponse<T> {
 		return BaseResponse
 			.<T>builder()
 			.code(code.getCode())
+				.status(code.getStatus())
 			.message(code.getMessage())
 			.data(data)
 			.build();


### PR DESCRIPTION
## 🔖 PR 유형
- [ ] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [X] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
gpt 연동 및 상품 저장 로직에서 이미지를 multifile 말고 url로 받아오는 로직으로 수정합니다.

## 🔧 작업 내용
- BaseResponse 생성시 status 추가
- gpt 연동 로직 수정
- 상품 저장 로직 수정

## ✅ 체크리스트
- [X] 테스트 완료(Postman, Swagger)

## 📝 기타 참고 사항
- 주의할 점, 추후 리팩토링 필요성 등

## 📎 관련 이슈
Close #32