### PR TITLE
[Feat] 상품 조회 시 반환 타입에 전체 인원 수와 가격을 추가

### DIFF
--- a/src/main/java/hackathon/kb/chakchak/domain/product/api/dto/ProductSaveRequest.java
+++ b/src/main/java/hackathon/kb/chakchak/domain/product/api/dto/ProductSaveRequest.java
@@ -4,6 +4,7 @@ import hackathon.kb.chakchak.domain.product.domain.enums.Category;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -25,7 +26,7 @@ public class ProductSaveRequest {
     private List<String> tags;
 
     @Schema(description = "상품 가격", example = "4800")
-    private Long price;
+    private BigDecimal price;
 
     @Schema(description = "쿠폰 사용 가능 여부", example = "true")
     private Boolean isCoupon;

--- a/src/main/java/hackathon/kb/chakchak/domain/product/domain/dto/ProductReadResponseDto.java
+++ b/src/main/java/hackathon/kb/chakchak/domain/product/domain/dto/ProductReadResponseDto.java
@@ -4,6 +4,7 @@ import hackathon.kb.chakchak.domain.product.domain.enums.Category;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -22,13 +23,17 @@ public record ProductReadResponseDto(
 	@Schema(description = "상품 카테고리", example = "의류")
 	Category category,
 	@Schema(description = "상품 가격", example = "1000000")
-	Long price,
+	BigDecimal price,
 	@Schema(description = "상품 설명", example = "이쁜 옷")
 	String description,
 	@Schema(description = "쿠폰 사용 가능 여부", example = "true")
 	Boolean isCoupon,
 	@Schema(description = "목표 모집 회원 수", example = "30")
 	Short targetAmount,
+	@Schema(description = "참여중인 인원", example = "22")
+	Short presentPersonCount,
+	@Schema(description = "현재 달성 액수", example = "34200000")
+	BigDecimal totalPrice,
 	@Schema(description = "모집 시작 기간", example = "2025-09-01T10:00:00")
 	LocalDateTime recruitmentStartPeriod,
 	@Schema(description = "모집 종료 기간", example = "2025-09-01T10:00:00")

--- a/src/main/java/hackathon/kb/chakchak/domain/product/domain/entity/Product.java
+++ b/src/main/java/hackathon/kb/chakchak/domain/product/domain/entity/Product.java
@@ -10,6 +10,7 @@ import hackathon.kb.chakchak.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -52,7 +53,7 @@ public class Product extends BaseEntity {
 	private Category category;
 
 	@Column(nullable = false)
-	private Long price;
+	private BigDecimal price;
 
 	@Lob
 	@Column(columnDefinition = "LONGTEXT", nullable = false)

--- a/src/main/java/hackathon/kb/chakchak/domain/product/service/ProductNarrativeService.java
+++ b/src/main/java/hackathon/kb/chakchak/domain/product/service/ProductNarrativeService.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -39,7 +40,7 @@ public class ProductNarrativeService {
                 .endCaptureId(0L) // 기본값(업데이트 예정)
                 .title(meta.getTitle())
                 .category(meta.getCategory())
-                .price(0L) // 기본값(업데이트 예정)
+                .price(BigDecimal.valueOf(0L)) // 기본값(업데이트 예정)
                 .description(meta.getSummary()) // 기본값(업데이트 예정)
                 .status(ProductStatus.DRAFT) // 임시 상태
                 .targetAmount(null) // 기본값(업데이트 예정)

--- a/src/main/java/hackathon/kb/chakchak/domain/product/util/ProductToDtoMapper.java
+++ b/src/main/java/hackathon/kb/chakchak/domain/product/util/ProductToDtoMapper.java
@@ -1,9 +1,11 @@
 package hackathon.kb.chakchak.domain.product.util;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
 import hackathon.kb.chakchak.domain.member.domain.entity.Seller;
+import hackathon.kb.chakchak.domain.order.domain.entity.Order;
 import hackathon.kb.chakchak.domain.product.domain.dto.ImageReadResponseDto;
 import hackathon.kb.chakchak.domain.product.domain.dto.ProductMemberReadResponseDto;
 import hackathon.kb.chakchak.domain.product.domain.dto.ProductReadResponseDto;
@@ -15,6 +17,7 @@ import hackathon.kb.chakchak.domain.product.domain.entity.Tag;
 public class ProductToDtoMapper {
 
 	public static ProductReadResponseDto productToProductReadResponseDto(Product product) {
+		Short presentPersonCount = getPresentPersonCount(product.getOrders());
 		return ProductReadResponseDto.builder()
 			.productId(product.getId())
 			.category(product.getCategory())
@@ -27,6 +30,8 @@ public class ProductToDtoMapper {
 			.recruitmentStartPeriod(product.getRecruitmentStartPeriod())
 			.seller(memberToProductMemberReadResponseDto(product.getSeller()))
 			.targetAmount(product.getTargetAmount())
+			.presentPersonCount(presentPersonCount)
+			.totalPrice(getTotalPrice(presentPersonCount, product.getPrice()))
 			.build();
 	}
 
@@ -48,5 +53,17 @@ public class ProductToDtoMapper {
 
 	public static ProductMemberReadResponseDto memberToProductMemberReadResponseDto(Seller seller) {
 		return new ProductMemberReadResponseDto(seller.getId(), seller.getCompanyName(), seller.getRepName(), seller.getCompanyPhoneNumber(), seller.getRoadNameAddress());
+	}
+
+	private static Short getPresentPersonCount(List<Order> orders){
+		Short presentPersonCount = 0;
+		for (Order order : orders) {
+			presentPersonCount = (short)(presentPersonCount + order.getQuantity());
+		}
+		return presentPersonCount;
+	}
+
+	private static BigDecimal getTotalPrice(Short presentPersonCount, BigDecimal price) {
+		return price.multiply(new BigDecimal(presentPersonCount));
 	}
 }


### PR DESCRIPTION
## 🔖 PR 유형
- [X] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
작업 목적을 간단히 설명해주세요.
상품 조회 시 반환 타입에 전체 인원 수와 전체 가격을 계산하여 추가.

## 🔧 작업 내용
- 작업한 기능 / 수정한 버그 목록
- 가격 자료형을 부동 소수점 문제를 해결하기 위해 BigDecimal로 변경
- 상품과 연관된 주문 내역을 모두 불러와 전체 인원수를 구함
- 전체 인원수를 기반으로 전체 가격을 구함
- 상품 조회 반환 Dto에 추가

## ✅ 체크리스트
- [X] 테스트 완료(Postman, Swagger)

## 📝 기타 참고 사항
- 주의할 점, 추후 리팩토링 필요성 등

## 📎 관련 이슈
Close #38 